### PR TITLE
Update ldap-group-sync.yml

### DIFF
--- a/roles/ocp4-idp/tasks/ldap-group-sync.yml
+++ b/roles/ocp4-idp/tasks/ldap-group-sync.yml
@@ -63,8 +63,7 @@
               name: ldap-group-syncer
               namespace: openshift-config
 
-    - name: Create the ConfigMap to house the LDAPSync yaml - LDAP
-      when: provider.type == "LDAP"
+    - name: Create the ConfigMap to house the LDAPSync yaml - LDAP or ActiveDirectory
       kubernetes.core.k8s:
         state: present
         merge_type:


### PR DESCRIPTION
We ran into a situation where the config map wasn't being created because we were using type=='ActiveDirectory'. Removing the conditional, since this whole section is conditional on provider.type.